### PR TITLE
Update Gelf message to be compliant with GELF 1.1 specification. 

### DIFF
--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -8,9 +8,7 @@ namespace NLog.Layouts.GelfLayout.Test
     [TestClass]
     public class GelfLayoutRendererTest
     {
-        //Newtonsoft.Json uses ISO 8601 by default to convert date. GelfConverted is using this converter.
-        const string ISO8601DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
-
+        
         [TestMethod]
         public void CanRenderGelf()
         {
@@ -33,8 +31,8 @@ namespace NLog.Layouts.GelfLayout.Test
             };
 
             var renderedGelf = gelfRenderer.Render(logEvent);
-            var expectedDateTime = dateTime.ToString(ISO8601DateTimeFormat, CultureInfo.CurrentCulture);
-            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":\"\",\"short_message\":\"{4}\",\"timestamp\":\"{5}\",\"version\":\"1.0\",\"_LoggerName\":\"{6}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, loggerName);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":0,\"short_message\":\"{4}\",\"timestamp\":{5},\"version\":\"1.1\",\"_LoggerName\":\"{6}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, loggerName);
 
             Assert.AreEqual(expectedGelf, renderedGelf);
         }
@@ -63,9 +61,10 @@ namespace NLog.Layouts.GelfLayout.Test
             };
 
             var renderedGelf = gelfRenderer.Render(logEvent);
-            var expectedDateTime = dateTime.ToString(ISO8601DateTimeFormat, CultureInfo.CurrentCulture);
-            const string expectedException = "\"_ExceptionSource\":\"NLog.Layouts.GelfLayout.Test\",\"_ExceptionMessage\":\"funny exception :D\",\"_StackTrace\":\"System.Exception: funny exception :D ---> System.Exception: very funny exception ::D\\r\\n   --- End of inner exception stack trace ---\\r\\n   at NLog.Layouts.GelfLayout.Test.FakeException.Throw() in c:\\\\GitHub\\\\NLog.GelfLayout\\\\src\\\\NLog.Layouts.GelfLayout.Test\\\\FakeException.cs:line 9\"";
-            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":\"\",\"short_message\":\"{4}\",\"timestamp\":\"{5}\",\"version\":\"1.0\",{6},\"_LoggerName\":\"{7}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, expectedException, loggerName);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            const string exceptionPath = "c:\\\\GitHub\\\\NLog.GelfLayout\\\\src\\\\NLog.Layouts.GelfLayout.Test\\\\FakeException.cs";
+            const string expectedException = "\"_ExceptionSource\":\"NLog.Layouts.GelfLayout.Test\",\"_ExceptionMessage\":\"funny exception :D\",\"_StackTrace\":\"System.Exception: funny exception :D ---> System.Exception: very funny exception ::D\\r\\n   --- End of inner exception stack trace ---\\r\\n   at NLog.Layouts.GelfLayout.Test.FakeException.Throw() in "+ exceptionPath + ":line 9\"";
+            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":0,\"short_message\":\"{4}\",\"timestamp\":{5},\"version\":\"1.1\",{6},\"_LoggerName\":\"{7}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, expectedException, loggerName);
 
             Assert.AreEqual(expectedGelf, renderedGelf);
         }

--- a/src/NLog.Layouts.GelfLayout/GelfMessage.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfMessage.cs
@@ -22,13 +22,13 @@ namespace NLog.Layouts.GelfLayout
         public int Level { get; set; }
 
         [JsonProperty("line")]
-        public string Line { get; set; }
+        public int Line { get; set; }
 
         [JsonProperty("short_message")]
         public string ShortMessage { get; set; }
 
         [JsonProperty("timestamp")]
-        public DateTime Timestamp { get; set; }
+        public decimal Timestamp { get; set; }
 
         [JsonProperty("version")]
         public string Version { get; set; }


### PR DESCRIPTION
Line field changed to numeric(int), and datetime field changed to Unix timestamp in UTC represented as decimal.

See related graylog server ticket about incorrect encoding of timestamp from multiple libraries:
https://github.com/Graylog2/graylog2-server/issues/4027