### PR TITLE
Handling NLog structured log messages (and update to NLog 4.5.3)

### DIFF
--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -1,14 +1,19 @@
-﻿using System;
-using System.Globalization;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
 using System.Net;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NLog.Layouts.GelfLayout.Test
 {
     [TestClass]
     public class GelfLayoutRendererTest
     {
-        
+        private enum TestMsgEnum
+        {
+            Enum1,
+            Enum2,
+        }
+
         [TestMethod]
         public void CanRenderGelf()
         {
@@ -18,8 +23,8 @@ namespace NLog.Layouts.GelfLayout.Test
             var message = "hello, gelf :)";
             var logLevel = LogLevel.Info;
             var hostname = Dns.GetHostName();
-
             var gelfRenderer = new GelfLayoutRenderer();
+
             gelfRenderer.Facility = facility;
 
             var logEvent = new LogEventInfo
@@ -32,7 +37,96 @@ namespace NLog.Layouts.GelfLayout.Test
 
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
-            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":0,\"short_message\":\"{4}\",\"timestamp\":{5},\"version\":\"1.1\",\"_LoggerName\":\"{6}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, loggerName);
+            var expectedGelf = string.Format(
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"\","
+                    + "\"full_message\":\"{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "\"_LoggerName\":\"{6}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                loggerName);
+
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfWithNonStringJsonValues()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = $"stringVal 1 {TestMsgEnum.Enum1} {dateTime.AddMinutes(-1)}";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfRenderer = new GelfLayoutRenderer();
+            string stringKey = "stringKey";
+            string stringVal = "stringVal";
+            string intKey = "intKey";
+            int intVal = 1;
+            string enumKey = "enumKey";
+            TestMsgEnum enumVal = TestMsgEnum.Enum1;
+            string dateTimeKey = "dateTimeKey";
+            DateTime dateTimeVal = dateTime.AddMinutes(-1);
+
+            gelfRenderer.Facility = facility;
+
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+                Properties =
+                {
+                    { stringKey, stringVal },
+                    { intKey, intVal },
+                    { enumKey, enumVal },
+                    { dateTimeKey, dateTimeVal }
+                }
+            };
+
+            var renderedGelf = gelfRenderer.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedProperties = String.Format(
+                "\"_{0}\":\"{1}\",\"_{2}\":{3},\"_{4}\":\"{5}\",\"_{6}\":{7}",
+                stringKey,
+                stringVal,
+                intKey,
+                intVal,
+                enumKey,
+                enumVal,
+                dateTimeKey,
+                GelfConverter.ToUnixTimeStamp(dateTimeVal));
+            var expectedGelf = string.Format(
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"\","
+                    + "\"full_message\":\"{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "{6},"
+                    + "\"_LoggerName\":\"{7}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                expectedProperties,
+                loggerName);
 
             Assert.AreEqual(expectedGelf, renderedGelf);
         }
@@ -47,8 +141,8 @@ namespace NLog.Layouts.GelfLayout.Test
             var logLevel = LogLevel.Fatal;
             var hostname = Dns.GetHostName();
             var exception = FakeException.Throw();
-
             var gelfRenderer = new GelfLayoutRenderer();
+
             gelfRenderer.Facility = facility;
 
             var logEvent = new LogEventInfo
@@ -59,12 +153,40 @@ namespace NLog.Layouts.GelfLayout.Test
                 TimeStamp = dateTime,
                 Exception = exception,
             };
-
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
-            const string exceptionPath = "c:\\\\GitHub\\\\NLog.GelfLayout\\\\src\\\\NLog.Layouts.GelfLayout.Test\\\\FakeException.cs";
-            const string expectedException = "\"_ExceptionSource\":\"NLog.Layouts.GelfLayout.Test\",\"_ExceptionMessage\":\"funny exception :D\",\"_StackTrace\":\"System.Exception: funny exception :D ---> System.Exception: very funny exception ::D\\r\\n   --- End of inner exception stack trace ---\\r\\n   at NLog.Layouts.GelfLayout.Test.FakeException.Throw() in "+ exceptionPath + ":line 9\"";
-            var expectedGelf = string.Format("{{\"facility\":\"{0}\",\"file\":\"\",\"full_message\":\"{1}\",\"host\":\"{2}\",\"level\":{3},\"line\":0,\"short_message\":\"{4}\",\"timestamp\":{5},\"version\":\"1.1\",{6},\"_LoggerName\":\"{7}\"}}", facility, message, hostname, logLevel.GetOrdinal(), message, expectedDateTime, expectedException, loggerName);
+            string executingDirectory = Directory.GetCurrentDirectory();
+            string srcDirectory =
+                executingDirectory.Substring(0, executingDirectory.IndexOf("bin")).Replace("\\", "\\\\");
+            string exceptionPath = $"{srcDirectory}FakeException.cs";
+            string expectedException =
+                "\"_ExceptionSource\":\"NLog.Layouts.GelfLayout.Test\","
+                    + "\"_ExceptionMessage\":\"funny exception :D\","
+                    + "\"_StackTrace\":\"System.Exception: funny exception :D ---> System.Exception: very funny "
+                    + "exception ::D\\r\\n   --- End of inner exception stack trace ---\\r\\n   "
+                    + "at NLog.Layouts.GelfLayout.Test.FakeException.Throw() in "
+                    + exceptionPath
+                    + ":line 9\"";
+            var expectedGelf = string.Format(
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"\","
+                    + "\"full_message\":\"{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "{6},"
+                    + "\"_LoggerName\":\"{7}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                expectedException,
+                loggerName);
 
             Assert.AreEqual(expectedGelf, renderedGelf);
         }

--- a/src/NLog.Layouts.GelfLayout.Test/NLog.Layouts.GelfLayout.Test.csproj
+++ b/src/NLog.Layouts.GelfLayout.Test/NLog.Layouts.GelfLayout.Test.csproj
@@ -35,11 +35,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\NLog.Layouts.GelfLayout\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.4.5.3\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/src/NLog.Layouts.GelfLayout.Test/packages.config
+++ b/src/NLog.Layouts.GelfLayout.Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
+  <package id="NLog" version="4.5.3" targetFramework="net45" />
 </packages>

--- a/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
+++ b/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
@@ -43,12 +43,16 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>packages\NLog.4.5.3\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/NLog.Layouts.GelfLayout/packages.config
+++ b/src/NLog.Layouts.GelfLayout/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net45" />
+  <package id="NLog" version="4.5.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
strings.  This led to missing fields if the properties were numeric,
dates or enumerated values.

The GelfConverter now handles the properties as follows:
* Enum values are converted to string explicitly (i.e. their integer
 value is currently lost.  This aids reading of the data without
 knowing the internals of the software that produced them).
* DateTime values are converted to Unix timestamps.
* All others are added directly as JTokens using JToken.FromObject.

The current implementation does not take into account nested structures.
So if the Property.Value is a complex object that contains enumerated
values, etc., the resulting JSON may not be valid under the GELF spec.