### PR TITLE
GelfConverter - Attempt to produce unique timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For instance the following configuration writes log messages to a [RabbitMQ-adol
 
 In this example there would be a [Graylog2] server that consumes the queued [GELF] messages. 
 
-### Sample Usage with NLog Network Target
+### Sample Usage with NLog Network Target and HTTP
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
@@ -54,6 +54,24 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
 
   <rules>
     <logger name="*" minlevel="Debug" writeTo="GelfHttp" />
+  </rules>
+</nlog>
+```
+
+### Sample Usage with NLog Network Target and TCP
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+  <extensions>
+    <add assembly="NLog.Layouts.GelfLayout" />
+  </extensions>
+  
+  <targets async="true">
+	<target xsi:type="Network" name="GelfTcp" address="tcp://graylog:12200" layout="${gelf:facility=MyFacility}" newLine="true" lineEnding="Null" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Debug" writeTo="GelfTcp" />
   </rules>
 </nlog>
 ```

--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -57,6 +57,15 @@ namespace NLog.Layouts.GelfLayout.Test
                 loggerName);
 
             Assert.AreEqual(expectedGelf, renderedGelf);
+            Assert.AreEqual(expectedGelf, gelfRenderer.Render(logEvent));
+
+            gelfRenderer.FixDuplicateTimestamp = true;
+            renderedGelf = gelfRenderer.Render(logEvent);
+            var renderedGelfWithUniqueTime1 = gelfRenderer.Render(logEvent);
+            var renderedGelfWithUniqueTime2 = gelfRenderer.Render(logEvent);
+            Assert.AreNotEqual(renderedGelf, renderedGelfWithUniqueTime1);
+            Assert.AreNotEqual(renderedGelf, renderedGelfWithUniqueTime2);
+            Assert.AreNotEqual(renderedGelfWithUniqueTime1, renderedGelfWithUniqueTime2);
         }
 
         [TestMethod]

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -36,6 +36,9 @@ namespace NLog.Layouts.GelfLayout
         public bool IncludeLegacyFields { get => _renderer.IncludeLegacyFields; set => _renderer.IncludeLegacyFields = value; }
 
         /// <inheritdoc/>
+        public bool FixDuplicateTimestamp { get; set; }
+
+        /// <inheritdoc/>
         public Layout Facility { get => _renderer.Facility; set => _renderer.Facility = value; }
 
         /// <inheritdoc/>

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -38,6 +38,9 @@ namespace NLog.Layouts.GelfLayout
         public bool IncludeLegacyFields { get; set; }
 
         /// <inheritdoc/>
+        public bool FixDuplicateTimestamp { get; set; }
+
+        /// <inheritdoc/>
         public Layout Facility { get; set; }
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -25,6 +25,11 @@ namespace NLog.Layouts.GelfLayout
         bool IncludeLegacyFields { get; }
 
         /// <summary>
+        /// Allow adjustment of GELF-timestamp with 1/10th millisecond, when low timeprecision produces identical timestamps
+        /// </summary>
+        bool FixDuplicateTimestamp { get; }
+
+        /// <summary>
         /// Graylog Facility
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
For better sorting in "graylog web interface" and "Grafana".

Must be enabled explictly with `FixDuplicateTimestamp=true` (Default = `False`)

Can handle bursts of 9 unique timestamps within the same millisecond:

- If time-resolution is 16 millisecond, then it will support 500 msgs/sec. with unique timestamp.
- If time-resolution is 1 millisecond (AccurateUTC), then it will support 9000 msgs/sec with unique timestamp.

Requires that Elastic (or other back-end) uses "high-resolution" timestamp with higher resolution than just milliseconds.