### PR TITLE
Reduce nuget-dependencies for NetStandard2.0

### DIFF
--- a/src/NLog.Layouts.GelfLayout.Test/NLog.Layouts.GelfLayout.Test.csproj
+++ b/src/NLog.Layouts.GelfLayout.Test/NLog.Layouts.GelfLayout.Test.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>packages\NLog.4.5.3\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\NLog.Layouts.GelfLayout\packages\NLog.4.5.11\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/NLog.Layouts.GelfLayout.Test/packages.config
+++ b/src/NLog.Layouts.GelfLayout.Test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.5.3" targetFramework="net45" />
+  <package id="NLog" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -15,7 +15,7 @@ namespace NLog.Layouts.GelfLayout
     {
         private readonly GelfConverter _converter = new GelfConverter();
 
-        internal static readonly Layout _disableThreadAgnostic = "${threadid}";
+        internal static readonly Layout _disableThreadAgnostic = "${threadid:cached=true}";
 
         public GelfLayoutRenderer()
         {

--- a/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
+++ b/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;netstandard1.3</TargetFrameworks>
 
-    <Version>1.0</Version>
+    <Version>1.1</Version>
     <Title>NLog.GelfLayout</Title>
     <PackageId>NLog.GelfLayout</PackageId>
     <Company>Farzad Panahi</Company>
@@ -12,7 +12,7 @@
     <Copyright>Copyright 2018</Copyright>
 
     <PackageReleaseNotes>
-      Updated JSON-Serializer settings to better handle rogue objects with cyclic object references
+      Updated to NLog 4.5.11 and Newtonsoft.Json 11.0.2 to reduce dependencies for NetStandard2.0
     </PackageReleaseNotes>
     <PackageTags>NLog;Gelf;graylog2;Log;Logging</PackageTags>
     <PackageProjectUrl>https://github.com/farzadpanahi/NLog.GelfLayout</PackageProjectUrl>
@@ -25,7 +25,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="NLog" Version="4.5.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated to NLog 4.5.11 and Newtonsoft.Json 11.0.2.

No longer inherits NetStandard1.3 dependencies: https://www.nuget.org/packages/Newtonsoft.Json/10.0.3