### PR TITLE
GelfLayout - IncludeLegacyFields = false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ PM> Install-Package NLog.GelfLayout
 ```
 
 ### Parameters
-- _IncludeAllProperties_ - Include all properties from the LogEvent. Boolean. Default = true
-- _IncludeMdlc_ - Include all properties from NLog MDLC / MEL BeginScope. Boolean. Default = false
+- _IncludeEventProperties_ - Include all properties from the LogEvent. Boolean. Default = true
+- _IncludeScopeProperties_ - Include all properties from NLog MDLC / MEL BeginScope. Boolean. Default = false
 - _ExcludeProperties_ - Comma separated string with LogEvent property names to exclude. 
-- _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = true
-- _Facility_ - Graylog Facility. Ignored when IncludeLegacyFields=False
+- _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = false
+- _Facility_ - Legacy Graylog Facility, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
 
 ### Sample Usage with RabbitMQ Target
 You can configure this layout for [NLog] Targets that respect Layout attribute. 
@@ -36,7 +36,7 @@ For instance the following configuration writes log messages to a [RabbitMQ-adol
             exchange="logmessages-gelf"
             durable="true"
             useJSON="false"
-            layout="${gelf:facility=MyFacility}"
+            layout="${gelf}"
     />
   </targets>
 
@@ -57,7 +57,7 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
   </extensions>
   
   <targets async="true">
-	<target xsi:type="Network" name="GelfHttp" address="http://localhost:12201/gelf" layout="${gelf:facility=MyFacility}" />
+	<target xsi:type="Network" name="GelfHttp" address="http://localhost:12201/gelf" layout="${gelf}" />
   </targets>
 
   <rules>
@@ -75,7 +75,7 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
   </extensions>
   
   <targets async="true">
-	<target xsi:type="Network" name="GelfTcp" address="tcp://graylog:12200" layout="${gelf:facility=MyFacility}" newLine="true" lineEnding="Null" />
+	<target xsi:type="Network" name="GelfTcp" address="tcp://graylog:12200" layout="${gelf}" newLine="true" lineEnding="Null" />
   </targets>
 
   <rules>
@@ -95,7 +95,7 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
   
   <targets async="true">
 	<target xsi:type="Network" name="GelfHttp" address="http://localhost:12201/gelf">
-		<layout type="GelfLayout" facility="MyFacility">
+		<layout type="GelfLayout">
 			<field name="threadid" layout="${threadid}" />
 		</layout>
 	</target>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NLog.GelfLayout
 [![Version](https://img.shields.io/nuget/v/NLog.GelfLayout.svg)](https://www.nuget.org/packages/NLog.GelfLayout) 
 
-GelfLayout-package contains custom layout renderer for [NLog] to format log messages as [GELF] Json structures.
+GelfLayout-package contains custom layout renderer for [NLog] to format log messages as [GELF] Json structures for [GrayLog]-server.
 
 ## Usage
 
@@ -84,6 +84,27 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
 </nlog>
 ```
 
+### Sample Usage with NLog Network Target and UDP
+
+Notice the options `Compress="GZip"` and `compressMinBytes="1024"` requires NLog v5.0
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
+  <extensions>
+    <add assembly="NLog.Layouts.GelfLayout" />
+  </extensions>
+  
+  <targets async="true">
+	<target xsi:type="Network" name="GelfUdp" address="udp://graylog:12201" layout="${gelf}" compress="GZip" compressMinBytes="1000" maxMessageSize="8150" />
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="Debug" writeTo="GelfUdp" />
+  </rules>
+</nlog>
+```
+
 ### Sample Usage with custom extra fields
 
 ```xml
@@ -111,8 +132,8 @@ In this example there would be a [Graylog2] server that consumes the queued [GEL
 [GELF] converter module is all taken from [Gelf4NLog] by [Ozan Seymen](https://github.com/seymen)
 
 [NLog]: http://nlog-project.org/
-[GrayLog2]: http://graylog2.org/
-[Gelf]: https://www.graylog2.org/resources/gelf/specification
+[GrayLog]: https://www.graylog.org/features/gelf
+[GELF]: https://docs.graylog.org/docs/gelf
 [Gelf4NLog]: https://github.com/seymen/Gelf4NLog
 [RabbitMQ-haf]: https://github.com/haf/NLog.RabbitMQ
 [RabbitMQ-adolya]: https://www.nuget.org/packages/Nlog.RabbitMQ.Target/

--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -244,7 +244,7 @@ namespace NLog.Layouts.GelfLayout.Test
             var gelfRenderer = new GelfLayoutRenderer();
 
             gelfRenderer.Facility = facility;
-            gelfRenderer.IncludeMdlc = true;
+            gelfRenderer.IncludeScopeProperties = true;
 
             var logEvent = new LogEventInfo
             {
@@ -342,7 +342,7 @@ namespace NLog.Layouts.GelfLayout.Test
             var hostname = Dns.GetHostName();
             var gelfLayout = new GelfLayout();
             gelfLayout.Facility = facility;
-            gelfLayout.IncludeAllProperties = true;
+            gelfLayout.IncludeEventProperties = true;
 
             var logEvent = new LogEventInfo
             {
@@ -389,7 +389,7 @@ namespace NLog.Layouts.GelfLayout.Test
             var hostname = Dns.GetHostName();
             var gelfLayout = new GelfLayout();
             gelfLayout.Facility = facility;
-            gelfLayout.IncludeAllProperties = true;
+            gelfLayout.IncludeEventProperties = true;
             gelfLayout.ExcludeProperties.Add("BadBoy");
 
             var logEvent = new LogEventInfo

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -58,7 +58,7 @@ namespace NLog.Layouts.GelfLayout
             }
 
             //We will persist them "Additional Fields" according to Gelf spec
-            bool hasProperties = converterOptions.IncludeAllProperties && logEventInfo.HasProperties;
+            bool hasProperties = converterOptions.IncludeEventProperties && logEventInfo.HasProperties;
             if (hasProperties)
             {
                 bool hasExcludeProperties = converterOptions.ExcludeProperties?.Count > 0;
@@ -88,7 +88,7 @@ namespace NLog.Layouts.GelfLayout
             AddAdditionalField(jsonWriter, "_LoggerName", logEventInfo.LoggerName);
 
             ICollection<string> mdlcKeys = null;
-            if (converterOptions.IncludeMdlc)
+            if (converterOptions.IncludeScopeProperties)
             {
                 mdlcKeys = MappedDiagnosticsLogicalContext.GetNames();
                 bool foundMdlcItem = false;

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -27,13 +27,21 @@ namespace NLog.Layouts.GelfLayout
         public IList<GelfField> ExtraFields { get => _renderer.ExtraFields; set => _renderer.ExtraFields = value; }
 
         /// <inheritdoc/>
+        public bool IncludeEventProperties { get => _renderer.IncludeEventProperties; set => _renderer.IncludeEventProperties = value; }
+
+        /// <inheritdoc/>
+        public bool IncludeScopeProperties { get => _renderer.IncludeScopeProperties; set => _renderer.IncludeScopeProperties = value; }
+
+        /// <inheritdoc/>
         public ISet<string> ExcludeProperties { get => _renderer.ExcludeProperties; set => _renderer.ExcludeProperties = value; }
 
         /// <inheritdoc/>
-        public bool IncludeAllProperties { get => _renderer.IncludeAllProperties; set => _renderer.IncludeAllProperties = value; }
+        [Obsolete("Replaced by IncludeEventProperties")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <inheritdoc/>
-        public bool IncludeMdlc { get => _renderer.IncludeMdlc; set => _renderer.IncludeMdlc = value; }
+        [Obsolete("Replaced by IncludeScopeProperties")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
 
         /// <inheritdoc/>
         public bool IncludeLegacyFields { get => _renderer.IncludeLegacyFields; set => _renderer.IncludeLegacyFields = value; }

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Newtonsoft.Json;
 using NLog.LayoutRenderers;
 using NLog.Config;
+using System;
 
 namespace NLog.Layouts.GelfLayout
 {
@@ -19,26 +20,44 @@ namespace NLog.Layouts.GelfLayout
 
         public GelfLayoutRenderer()
         {
-            IncludeAllProperties = true;
-            IncludeLegacyFields = true;
+            IncludeEventProperties = true;
         }
 
         /// <summary>
         /// Performance hack for NLog, that allows the Layout to dynamically disable <see cref="ThreadAgnosticAttribute"/> to ensure correct async context capture
         /// </summary>
-        public Layout DisableThreadAgnostic => IncludeMdlc ? _disableThreadAgnostic : null;
+        public Layout DisableThreadAgnostic => IncludeScopeProperties ? _disableThreadAgnostic : null;
 
         /// <inheritdoc/>
-        public bool IncludeAllProperties { get; set; }
+        public bool IncludeEventProperties { get; set; }
 
         /// <inheritdoc/>
-        public bool IncludeMdlc { get; set; }
+        public bool IncludeScopeProperties { get; set; }
 
         /// <inheritdoc/>
-        public bool IncludeLegacyFields { get; set; }
+        [Obsolete("Replaced by IncludeEventProperties")]
+        public bool IncludeAllProperties { get => IncludeEventProperties; set => IncludeEventProperties = value; }
 
         /// <inheritdoc/>
-        public Layout Facility { get; set; }
+        [Obsolete("Replaced by IncludeScopeProperties")]
+        public bool IncludeMdlc { get => IncludeScopeProperties; set => IncludeScopeProperties = value; }
+
+        /// <inheritdoc/>
+        public bool IncludeLegacyFields { get => _includeLegacyFields ?? false; set => _includeLegacyFields = value; }
+        private bool? _includeLegacyFields;
+
+        /// <inheritdoc/>
+        public Layout Facility
+        {
+            get => _facility;
+            set
+            {
+                _facility = value;
+                if (!_includeLegacyFields.HasValue)
+                    IncludeLegacyFields = true;
+            }
+        }
+        private Layout _facility;
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }
 

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace NLog.Layouts.GelfLayout
 {
@@ -7,12 +8,24 @@ namespace NLog.Layouts.GelfLayout
         /// <summary>
         /// Gets or sets a value indicating whether to include contents of the <see cref="MappedDiagnosticsLogicalContext"/> dictionary.
         /// </summary>
+        [Obsolete("Replaced by IncludeScopeProperties")]
         bool IncludeMdlc { get; }
 
         /// <summary>
         /// Gets or sets the option to include all properties from the log events
         /// </summary>
+        [Obsolete("Replaced by IncludeEventProperties")]
         bool IncludeAllProperties { get; }
+
+        /// <summary>
+        /// Gets or sets the option to include event properties from the log events
+        /// </summary>
+        bool IncludeEventProperties { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include properties from the NLog ScopeContext-dictionary
+        /// </summary>
+        bool IncludeScopeProperties { get; }
 
         /// <summary>
         /// Gets the array of additional custom fields to include in the Gelf message

--- a/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
+++ b/src/NLog.Layouts.GelfLayout/NLog.Layouts.GelfLayout.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net471;netstandard2.0;netstandard1.3</TargetFrameworks>
 
-    <Version>1.2</Version>
+    <Version>1.3</Version>
     <Title>NLog.GelfLayout</Title>
     <PackageId>NLog.GelfLayout</PackageId>
     <Company>Farzad Panahi</Company>
@@ -12,7 +12,9 @@
     <Copyright>Copyright 2020</Copyright>
 
     <PackageReleaseNotes>
-Added support for ExcludeProperties and improve handling of reflection types
+IncludeLegacyFields is now false by default, unless having specified legacy Facility-field 
+Updated to .NET Framework 4.7.1
+Introduced IncludeEventProperties + IncludeScopeProperties to match NLog 5.0
     </PackageReleaseNotes>
     <PackageTags>NLog;Gelf;graylog2;Log;Logging</PackageTags>
     <PackageProjectUrl>https://github.com/farzadpanahi/NLog.GelfLayout</PackageProjectUrl>


### PR DESCRIPTION
Skip legacy-fields from GELF Spec ver. 1.0, unless having explictly specified Facility-field.

Introduced new settings-names to match the changes in [NLog 5.0](https://nlog-project.org/2021/08/25/nlog-5-0-preview1-ready.html):
- IncludeEventProperties - Replacement for IncludeAllProperties
- IncludeScopeProperties - Replacement for IncludeMdlc

Updated from net45 to net471 because the build-pipeline failed with `.NETFramework version=v4.5 were not found`