### PR TITLE
Replaced Dns.GetHostName with ${hostname}

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ PM> Install-Package NLog.GelfLayout
 - _IncludeScopeProperties_ - Include all properties from NLog MDLC / MEL BeginScope. Boolean. Default = false
 - _ExcludeProperties_ - Comma separated string with LogEvent property names to exclude. 
 - _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = false
-- _Facility_ - Legacy Graylog Facility, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
+- _Facility_ - Legacy Graylog Message Facility-field, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
+- _HostName_ - Override Graylog Message Host-field. Default: `${hostname}`
 
 ### Sample Usage with RabbitMQ Target
 You can configure this layout for [NLog] Targets that respect Layout attribute. 

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -50,6 +50,9 @@ namespace NLog.Layouts.GelfLayout
         public Layout Facility { get => _renderer.Facility; set => _renderer.Facility = value; }
 
         /// <inheritdoc/>
+        public Layout HostName { get => _renderer.HostName; set => _renderer.HostName = value; }
+
+        /// <inheritdoc/>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             _renderer.RenderAppend(logEvent, target);

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -53,11 +53,14 @@ namespace NLog.Layouts.GelfLayout
             set
             {
                 _facility = value;
-                if (!_includeLegacyFields.HasValue)
+                if (!_includeLegacyFields.HasValue && value != null && !(value is SimpleLayout simpleLayout && simpleLayout.IsFixedText && string.IsNullOrEmpty(simpleLayout.FixedText)))
                     IncludeLegacyFields = true;
             }
         }
         private Layout _facility;
+
+        /// <inheritdoc/>
+        public Layout HostName { get; set; } = "${hostname}";
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }
 

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -43,11 +43,16 @@ namespace NLog.Layouts.GelfLayout
         bool IncludeLegacyFields { get; }
 
         /// <summary>
-        /// Graylog Facility
+        /// Graylog Message Facility-field
         /// </summary>
         /// <remarks>
         /// Ignored when <see cref="IncludeLegacyFields"/> = false
         /// </remarks>
         Layout Facility { get; }
+
+        /// <summary>
+        /// Graylog Message Host-field
+        /// </summary>
+        Layout HostName { get; }
     }
 }


### PR DESCRIPTION
NLog [${hostname}](https://github.com/NLog/NLog/wiki/HostName-Layout-Renderer) has multiple fallbacks by default, that works well on Linux and Windows:
```c#
        private static string GetHostName()
        {
            return TryLookupValue(() => Environment.GetEnvironmentVariable("HOSTNAME"), "HOSTNAME")
                ?? TryLookupValue(() => System.Net.Dns.GetHostName(), "DnsHostName")
#if !NETSTANDARD1_3
                ?? TryLookupValue(() => Environment.MachineName, "MachineName")
#endif
                ?? TryLookupValue(() => Environment.GetEnvironmentVariable("MACHINENAME"), "MachineName");
        }
```
Also allows the user to override the GrayLog Message host-field, if wanting the ip-address instead. Ex. `hostname=${local-ip}`