### PR TITLE
Added Custom Message Format - Default Value `${message}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ PM> Install-Package NLog.GelfLayout
 - _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = false
 - _Facility_ - Legacy Graylog Message Facility-field, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
 - _HostName_ - Override Graylog Message Host-field. Default: `${hostname}`
+- _MessageLayout_ - Override Default Message Layout. Default `${message}`
 
 ### Sample Usage with RabbitMQ Target
 You can configure this layout for [NLog] Targets that respect Layout attribute. 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ PM> Install-Package NLog.GelfLayout
 - _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = false
 - _Facility_ - Legacy Graylog Message Facility-field, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
 - _HostName_ - Override Graylog Message Host-field. Default: `${hostname}`
-- _MessageLayout_ - Override Default Message Layout. Default `${message}`
+- _FullMessageLayout_ - Override Default Full Message Layout. Default `${message}`
+- _ShortMessageLayout_ - Override Default Short Message Layout. Default `${message}`
 
 ### Sample Usage with RabbitMQ Target
 You can configure this layout for [NLog] Targets that respect Layout attribute. 

--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -424,7 +424,7 @@ namespace NLog.Layouts.GelfLayout.Test
             Assert.AreEqual(expectedGelf, renderedGelf);
         }
         
-                [TestMethod]
+        [TestMethod]
         public void CanRenderGelfCustomMessage()
         {
             var loggerName = "TestLogger";
@@ -444,7 +444,8 @@ namespace NLog.Layouts.GelfLayout.Test
                 Message = message,
                 TimeStamp = dateTime,
             };
-            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
+            gelfRenderer.ShortMessageLayout = "short|${message}";
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
             var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
@@ -454,7 +455,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "\"_LoggerName\":\"{6}\"}}",
@@ -480,8 +481,8 @@ namespace NLog.Layouts.GelfLayout.Test
             var gelfRenderer = new GelfLayoutRenderer();
 
             gelfRenderer.IncludeLegacyFields = false;
-            gelfRenderer.MessageLayout = "${hostname}|${message}";
-
+            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
+            gelfRenderer.ShortMessageLayout = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,
@@ -495,7 +496,7 @@ namespace NLog.Layouts.GelfLayout.Test
             var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
                 "{{\"version\":\"1.1\","
                     + "\"host\":\"{0}\","
-                    + "\"short_message\":\"{0}|{1}\","
+                    + "\"short_message\":\"short|{1}\","
                     + "\"full_message\":\"{0}|{2}\","
                     + "\"timestamp\":{3},"
                     + "\"level\":{4},"
@@ -531,7 +532,8 @@ namespace NLog.Layouts.GelfLayout.Test
 
             gelfRenderer.Facility = facility;
 
-            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
+            gelfRenderer.ShortMessageLayout = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -567,7 +569,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "{6},"
@@ -607,7 +609,8 @@ namespace NLog.Layouts.GelfLayout.Test
                 Exception = exception,
             };
 
-            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
+            gelfRenderer.ShortMessageLayout = "short|${message}";
             
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
@@ -631,7 +634,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "{6},"
@@ -661,7 +664,8 @@ namespace NLog.Layouts.GelfLayout.Test
 
             gelfRenderer.Facility = facility;
             gelfRenderer.IncludeScopeProperties = true;
-            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
+            gelfRenderer.ShortMessageLayout = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,
@@ -682,7 +686,7 @@ namespace NLog.Layouts.GelfLayout.Test
                         + "\"host\":\"{2}\","
                         + "\"level\":{3},"
                         + "\"line\":0,"
-                        + "\"short_message\":\"{2}|{4}\","
+                        + "\"short_message\":\"short|{4}\","
                         + "\"timestamp\":{5},"
                         + "\"version\":\"1.1\","
                         + "\"_LoggerName\":\"{6}\","
@@ -713,7 +717,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.ExtraFields.Add(new GelfField("ThreadId", "${threadid}") { PropertyType = typeof(int) });
 
-            gelfLayout.MessageLayout = "${hostname}|${message}";
+            gelfLayout.FullMessageLayout = "${hostname}|${message}";
+            gelfLayout.ShortMessageLayout = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -733,7 +738,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "\"_LoggerName\":\"{6}\","
@@ -762,7 +767,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.IncludeEventProperties = true;
 
-            gelfLayout.MessageLayout = "${hostname}|${message}";
+            gelfLayout.FullMessageLayout = "${hostname}|${message}";
+            gelfLayout.ShortMessageLayout = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -782,7 +788,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "\"_BadBoy\":{{\"BadArray\":[],\"BadProperty\":\"{6}\"}},"
@@ -811,7 +817,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.IncludeEventProperties = true;
             gelfLayout.ExcludeProperties.Add("BadBoy");
-            gelfLayout.MessageLayout = "${hostname}|${message}";
+            gelfLayout.FullMessageLayout = "${hostname}|${message}";
+            gelfLayout.ShortMessageLayout = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,
@@ -830,7 +837,7 @@ namespace NLog.Layouts.GelfLayout.Test
                     + "\"host\":\"{2}\","
                     + "\"level\":{3},"
                     + "\"line\":0,"
-                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"short_message\":\"short|{4}\","
                     + "\"timestamp\":{5},"
                     + "\"version\":\"1.1\","
                     + "\"_LoggerName\":\"{6}\"}}",

--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -423,6 +423,426 @@ namespace NLog.Layouts.GelfLayout.Test
                 loggerName);
             Assert.AreEqual(expectedGelf, renderedGelf);
         }
+        
+                [TestMethod]
+        public void CanRenderGelfCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfRenderer = new GelfLayoutRenderer();
+
+            gelfRenderer.Facility = facility;
+
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            var renderedGelf = gelfRenderer.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "\"_LoggerName\":\"{6}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                loggerName);
+
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelf11CustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfRenderer = new GelfLayoutRenderer();
+
+            gelfRenderer.IncludeLegacyFields = false;
+            gelfRenderer.MessageLayout = "${hostname}|${message}";
+
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+
+            var renderedGelf = gelfRenderer.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"version\":\"1.1\","
+                    + "\"host\":\"{0}\","
+                    + "\"short_message\":\"{0}|{1}\","
+                    + "\"full_message\":\"{0}|{2}\","
+                    + "\"timestamp\":{3},"
+                    + "\"level\":{4},"
+                    + "\"_LoggerName\":\"{5}\"}}",
+                hostname,
+                message,
+                message,
+                expectedDateTime,
+                logLevel.GetOrdinal(),
+                loggerName);
+
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfWithNonStringJsonValuesCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = $"stringVal 1 {GelfLayoutRendererTest.TestMsgEnum.Enum1} {dateTime.AddMinutes(-1)}";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfRenderer = new GelfLayoutRenderer();
+            string stringKey = "stringKey";
+            string stringVal = "stringVal";
+            string intKey = "intKey";
+            int intVal = 1;
+            string enumKey = "enumKey";
+            GelfLayoutRendererTest.TestMsgEnum enumVal = GelfLayoutRendererTest.TestMsgEnum.Enum1;
+            string dateTimeKey = "dateTimeKey";
+            DateTime dateTimeVal = dateTime.AddMinutes(-1);
+
+            gelfRenderer.Facility = facility;
+
+            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+                Properties =
+                {
+                    { stringKey, stringVal },
+                    { intKey, intVal },
+                    { enumKey, enumVal },
+                    { dateTimeKey, dateTimeVal }
+                }
+            };
+
+            var renderedGelf = gelfRenderer.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedProperties = String.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "\"_{0}\":\"{1}\",\"_{2}\":{3},\"_{4}\":\"{5}\",\"_{6}\":{7}",
+                stringKey,
+                stringVal,
+                intKey,
+                intVal,
+                enumKey,
+                enumVal,
+                dateTimeKey,
+                GelfConverter.ToUnixTimeStamp(dateTimeVal));
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "{6},"
+                    + "\"_LoggerName\":\"{7}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                expectedProperties,
+                loggerName);
+
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfExceptionCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Fatal;
+            var hostname = Dns.GetHostName();
+            var exception = FakeException.Throw();
+            var gelfRenderer = new GelfLayoutRenderer();
+
+            gelfRenderer.Facility = facility;
+
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+                Exception = exception,
+            };
+
+            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            
+            var renderedGelf = gelfRenderer.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            string executingDirectory = Directory.GetCurrentDirectory();
+            string srcDirectory =
+                executingDirectory.Substring(0, executingDirectory.IndexOf("bin")).Replace("\\", "\\\\");
+            string exceptionPath = $"{srcDirectory}FakeException.cs";
+            string expectedException =
+                "\"_ExceptionSource\":\"NLog.Layouts.GelfLayout.Test\","
+                    + "\"_ExceptionMessage\":\"funny exception :D\","
+                    + "\"_ExceptionType\":\"System.ArgumentException\","
+                    + "\"_StackTrace\":\"System.ArgumentException: funny exception :D\\r\\n ---> System.Exception: very funny "
+                    + "exception ::D\\r\\n   --- End of inner exception stack trace ---\\r\\n   "
+                    + "at NLog.Layouts.GelfLayout.Test.FakeException.Throw() in "
+                    + exceptionPath
+                    + ":line 9\"";
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "{6},"
+                    + "\"_LoggerName\":\"{7}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                expectedException,
+                loggerName);
+
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfIncludeMdlcCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfRenderer = new GelfLayoutRenderer();
+
+            gelfRenderer.Facility = facility;
+            gelfRenderer.IncludeScopeProperties = true;
+            gelfRenderer.MessageLayout = "${hostname}|${message}";
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+
+            Guid requestId = Guid.NewGuid();
+            using (var mdlc = NLog.MappedDiagnosticsLogicalContext.SetScoped("RequestId", requestId))
+            {
+                var renderedGelf = gelfRenderer.Render(logEvent);
+                var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+                var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    "{{\"facility\":\"{0}\","
+                        + "\"file\":\"TestLogger\","
+                        + "\"full_message\":\"{2}|{1}\","
+                        + "\"host\":\"{2}\","
+                        + "\"level\":{3},"
+                        + "\"line\":0,"
+                        + "\"short_message\":\"{2}|{4}\","
+                        + "\"timestamp\":{5},"
+                        + "\"version\":\"1.1\","
+                        + "\"_LoggerName\":\"{6}\","
+                        + "\"_RequestId\":\"{7}\"}}",
+                    facility,
+                    message,
+                    hostname,
+                    logLevel.GetOrdinal(),
+                    message,
+                    expectedDateTime,
+                    loggerName,
+                    requestId);
+                Assert.AreEqual(expectedGelf, renderedGelf);
+            }
+        }
+
+        [TestMethod]
+        public void CanRenderGelfAdditionalFieldsCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfLayout= new GelfLayout();
+
+            gelfLayout.Facility = facility;
+            gelfLayout.ExtraFields.Add(new GelfField("ThreadId", "${threadid}") { PropertyType = typeof(int) });
+
+            gelfLayout.MessageLayout = "${hostname}|${message}";
+            
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+
+            int threadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+            var renderedGelf = gelfLayout.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "\"_LoggerName\":\"{6}\","
+                    + "\"_ThreadId\":{7}}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                loggerName,
+                threadId);
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfWithBadObjectCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfLayout = new GelfLayout();
+            gelfLayout.Facility = facility;
+            gelfLayout.IncludeEventProperties = true;
+
+            gelfLayout.MessageLayout = "${hostname}|${message}";
+            
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+            logEvent.Properties["BadBoy"] = new GelfLayoutRendererTest.BadLogObject();
+
+            var renderedGelf = gelfLayout.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "\"_BadBoy\":{{\"BadArray\":[],\"BadProperty\":\"{6}\"}},"
+                    + "\"_LoggerName\":\"{7}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                typeof(GelfLayoutRendererTest.BadLogObject).Assembly.ToString(),
+                loggerName);
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
+
+        [TestMethod]
+        public void CanRenderGelfWithBadObjectExcludedCustomMessage()
+        {
+            var loggerName = "TestLogger";
+            var facility = "TestFacility";
+            var dateTime = DateTime.Now;
+            var message = "hello, gelf :)";
+            var logLevel = LogLevel.Info;
+            var hostname = Dns.GetHostName();
+            var gelfLayout = new GelfLayout();
+            gelfLayout.Facility = facility;
+            gelfLayout.IncludeEventProperties = true;
+            gelfLayout.ExcludeProperties.Add("BadBoy");
+            gelfLayout.MessageLayout = "${hostname}|${message}";
+            var logEvent = new LogEventInfo
+            {
+                LoggerName = loggerName,
+                Level = logLevel,
+                Message = message,
+                TimeStamp = dateTime,
+            };
+            logEvent.Properties["BadBoy"] = new GelfLayoutRendererTest.BadLogObject();
+
+            var renderedGelf = gelfLayout.Render(logEvent);
+            var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
+            var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                "{{\"facility\":\"{0}\","
+                    + "\"file\":\"TestLogger\","
+                    + "\"full_message\":\"{2}|{1}\","
+                    + "\"host\":\"{2}\","
+                    + "\"level\":{3},"
+                    + "\"line\":0,"
+                    + "\"short_message\":\"{2}|{4}\","
+                    + "\"timestamp\":{5},"
+                    + "\"version\":\"1.1\","
+                    + "\"_LoggerName\":\"{6}\"}}",
+                facility,
+                message,
+                hostname,
+                logLevel.GetOrdinal(),
+                message,
+                expectedDateTime,
+                loggerName);
+            Assert.AreEqual(expectedGelf, renderedGelf);
+        }
 
         public class BadLogObject
         {

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -27,14 +27,14 @@ namespace NLog.Layouts.GelfLayout
         public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = converterOptions.FullMessageLayout.Render(logEventInfo);
+            var logEventMessage = converterOptions.FullMessageLayout.Render(logEventInfo) ?? string.Empty;
             if (logEventMessage.Length > FullMessageMaxLength)
             {
                 logEventMessage = logEventMessage.Substring(0, FullMessageMaxLength);
             }
 
             //Figure out the short message
-            var shortMessage = converterOptions.ShortMessageLayout.Render(logEventInfo);
+            var shortMessage = converterOptions.ShortMessageLayout.Render(logEventInfo) ?? string.Empty;
             if (shortMessage.Length > ShortMessageMaxLength)
             {
                 shortMessage = shortMessage.Substring(0, ShortMessageMaxLength);

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -24,10 +24,10 @@ namespace NLog.Layouts.GelfLayout
 
         private string _hostName;
 
-        public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions)
+        public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions, Layout messageLayout)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = logEventInfo.FormattedMessage ?? string.Empty;
+            var logEventMessage = messageLayout.Render(logEventInfo);
             if (logEventMessage.Length > FullMessageMaxLength)
             {
                 logEventMessage = logEventMessage.Substring(0, FullMessageMaxLength);

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -24,17 +24,17 @@ namespace NLog.Layouts.GelfLayout
 
         private string _hostName;
 
-        public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions, Layout messageLayout)
+        public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = messageLayout.Render(logEventInfo);
+            var logEventMessage = converterOptions.FullMessageLayout.Render(logEventInfo);
             if (logEventMessage.Length > FullMessageMaxLength)
             {
                 logEventMessage = logEventMessage.Substring(0, FullMessageMaxLength);
             }
 
             //Figure out the short message
-            var shortMessage = logEventMessage;
+            var shortMessage = converterOptions.ShortMessageLayout.Render(logEventInfo);
             if (shortMessage.Length > ShortMessageMaxLength)
             {
                 shortMessage = shortMessage.Substring(0, ShortMessageMaxLength);

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -27,14 +27,14 @@ namespace NLog.Layouts.GelfLayout
         public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = converterOptions.FullMessageLayout.Render(logEventInfo) ?? string.Empty;
+            var logEventMessage = converterOptions.FullMessageLayout?.Render(logEventInfo) ?? string.Empty;
             if (logEventMessage.Length > FullMessageMaxLength)
             {
                 logEventMessage = logEventMessage.Substring(0, FullMessageMaxLength);
             }
 
             //Figure out the short message
-            var shortMessage = converterOptions.ShortMessageLayout.Render(logEventInfo) ?? string.Empty;
+            var shortMessage = converterOptions.ShortMessageLayout?.Render(logEventInfo) ?? string.Empty;
             if (shortMessage.Length > ShortMessageMaxLength)
             {
                 shortMessage = shortMessage.Substring(0, ShortMessageMaxLength);

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -53,11 +53,10 @@ namespace NLog.Layouts.GelfLayout
         public Layout HostName { get => _renderer.HostName; set => _renderer.HostName = value; }
 
         /// <inheritdoc/>
-        public Layout MessageLayout
-        {
-            get => _renderer.MessageLayout;
-            set => _renderer.MessageLayout = value;
-        }
+        public Layout FullMessageLayout { get => _renderer.FullMessageLayout; set => _renderer.FullMessageLayout = value; }
+        
+        /// <inheritdoc/>
+        public Layout ShortMessageLayout { get => _renderer.ShortMessageLayout; set => _renderer.ShortMessageLayout = value; }
         
         /// <inheritdoc/>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -53,6 +53,13 @@ namespace NLog.Layouts.GelfLayout
         public Layout HostName { get => _renderer.HostName; set => _renderer.HostName = value; }
 
         /// <inheritdoc/>
+        public Layout MessageLayout
+        {
+            get => _renderer.MessageLayout;
+            set => _renderer.MessageLayout = value;
+        }
+        
+        /// <inheritdoc/>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
             _renderer.RenderAppend(logEvent, target);

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -61,12 +61,17 @@ namespace NLog.Layouts.GelfLayout
 
         /// <inheritdoc/>
         public Layout HostName { get; set; } = "${hostname}";
+        
+        /// <inheritdoc/>
+        public Layout MessageLayout { get; set; } = "${message}";
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }
 
         internal IList<GelfField> ExtraFields { get; set; }
 
         public ISet<string> ExcludeProperties { get; set; } = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+
 
         internal void RenderAppend(LogEventInfo logEvent, StringBuilder builder)
         {
@@ -84,7 +89,7 @@ namespace NLog.Layouts.GelfLayout
                 {
                     JsonTextWriter jw = new JsonTextWriter(sw);
                     jw.Formatting = Formatting.None;
-                    _converter.ConvertToGelfMessage(jw, logEvent, this);
+                    _converter.ConvertToGelfMessage(jw, logEvent, this, MessageLayout);
                 }
             }
             catch

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -63,7 +63,10 @@ namespace NLog.Layouts.GelfLayout
         public Layout HostName { get; set; } = "${hostname}";
         
         /// <inheritdoc/>
-        public Layout MessageLayout { get; set; } = "${message}";
+        public Layout FullMessageLayout { get; set; } = "${message}";
+        
+        /// <inheritdoc/>
+        public Layout ShortMessageLayout { get; set; } = "${message}";
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }
 
@@ -89,7 +92,7 @@ namespace NLog.Layouts.GelfLayout
                 {
                     JsonTextWriter jw = new JsonTextWriter(sw);
                     jw.Formatting = Formatting.None;
-                    _converter.ConvertToGelfMessage(jw, logEvent, this, MessageLayout);
+                    _converter.ConvertToGelfMessage(jw, logEvent, this);
                 }
             }
             catch

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -54,5 +54,10 @@ namespace NLog.Layouts.GelfLayout
         /// Graylog Message Host-field
         /// </summary>
         Layout HostName { get; }
+        
+        /// <summary>
+        /// Layout of the rendered Message
+        /// </summary>
+        Layout MessageLayout { get; }
     }
 }

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -56,8 +56,13 @@ namespace NLog.Layouts.GelfLayout
         Layout HostName { get; }
         
         /// <summary>
-        /// Layout of the rendered Message
+        /// Layout of the rendered Full Message
         /// </summary>
-        Layout MessageLayout { get; }
+        Layout FullMessageLayout { get; }
+        
+        /// <summary>
+        /// Layout of the rendered Short Message
+        /// </summary>
+        Layout ShortMessageLayout { get; }
     }
 }


### PR DESCRIPTION
Added support to customize the Message Layout.
Default is `${message}` so the behaviour stays the same.