### PR TITLE
Removed Layout-suffix from FullMessage + ShortMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ PM> Install-Package NLog.GelfLayout
 - _IncludeLegacyFields_ - Include deprecated fields no longer part of official GelfVersion 1.1 specification. Boolean. Default = false
 - _Facility_ - Legacy Graylog Message Facility-field, when specifed it will fallback to legacy GelfVersion 1.0. Ignored when IncludeLegacyFields=False
 - _HostName_ - Override Graylog Message Host-field. Default: `${hostname}`
-- _FullMessageLayout_ - Override Default Full Message Layout. Default `${message}`
-- _ShortMessageLayout_ - Override Default Short Message Layout. Default `${message}`
+- _FullMessage_ - Override Graylog Full-Message-field. Default: `${message}`
+- _ShortMessage_ - Override Graylog Short-Message-field. Default: `${message}`
 
 ### Sample Usage with RabbitMQ Target
 You can configure this layout for [NLog] Targets that respect Layout attribute. 

--- a/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
+++ b/src/NLog.Layouts.GelfLayout.Test/GelfLayoutRendererTest.cs
@@ -444,8 +444,8 @@ namespace NLog.Layouts.GelfLayout.Test
                 Message = message,
                 TimeStamp = dateTime,
             };
-            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
-            gelfRenderer.ShortMessageLayout = "short|${message}";
+            gelfRenderer.FullMessage = "${hostname}|${message}";
+            gelfRenderer.ShortMessage = "short|${message}";
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
             var expectedGelf = string.Format(System.Globalization.CultureInfo.InvariantCulture,
@@ -481,8 +481,8 @@ namespace NLog.Layouts.GelfLayout.Test
             var gelfRenderer = new GelfLayoutRenderer();
 
             gelfRenderer.IncludeLegacyFields = false;
-            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
-            gelfRenderer.ShortMessageLayout = "short|${message}";
+            gelfRenderer.FullMessage = "${hostname}|${message}";
+            gelfRenderer.ShortMessage = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,
@@ -532,8 +532,8 @@ namespace NLog.Layouts.GelfLayout.Test
 
             gelfRenderer.Facility = facility;
 
-            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
-            gelfRenderer.ShortMessageLayout = "short|${message}";
+            gelfRenderer.FullMessage = "${hostname}|${message}";
+            gelfRenderer.ShortMessage = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -609,8 +609,8 @@ namespace NLog.Layouts.GelfLayout.Test
                 Exception = exception,
             };
 
-            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
-            gelfRenderer.ShortMessageLayout = "short|${message}";
+            gelfRenderer.FullMessage = "${hostname}|${message}";
+            gelfRenderer.ShortMessage = "short|${message}";
             
             var renderedGelf = gelfRenderer.Render(logEvent);
             var expectedDateTime = GelfConverter.ToUnixTimeStamp(dateTime);
@@ -664,8 +664,8 @@ namespace NLog.Layouts.GelfLayout.Test
 
             gelfRenderer.Facility = facility;
             gelfRenderer.IncludeScopeProperties = true;
-            gelfRenderer.FullMessageLayout = "${hostname}|${message}";
-            gelfRenderer.ShortMessageLayout = "short|${message}";
+            gelfRenderer.FullMessage = "${hostname}|${message}";
+            gelfRenderer.ShortMessage = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,
@@ -717,8 +717,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.ExtraFields.Add(new GelfField("ThreadId", "${threadid}") { PropertyType = typeof(int) });
 
-            gelfLayout.FullMessageLayout = "${hostname}|${message}";
-            gelfLayout.ShortMessageLayout = "short|${message}";
+            gelfLayout.FullMessage = "${hostname}|${message}";
+            gelfLayout.ShortMessage = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -767,8 +767,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.IncludeEventProperties = true;
 
-            gelfLayout.FullMessageLayout = "${hostname}|${message}";
-            gelfLayout.ShortMessageLayout = "short|${message}";
+            gelfLayout.FullMessage = "${hostname}|${message}";
+            gelfLayout.ShortMessage = "short|${message}";
             
             var logEvent = new LogEventInfo
             {
@@ -817,8 +817,8 @@ namespace NLog.Layouts.GelfLayout.Test
             gelfLayout.Facility = facility;
             gelfLayout.IncludeEventProperties = true;
             gelfLayout.ExcludeProperties.Add("BadBoy");
-            gelfLayout.FullMessageLayout = "${hostname}|${message}";
-            gelfLayout.ShortMessageLayout = "short|${message}";
+            gelfLayout.FullMessage = "${hostname}|${message}";
+            gelfLayout.ShortMessage = "short|${message}";
             var logEvent = new LogEventInfo
             {
                 LoggerName = loggerName,

--- a/src/NLog.Layouts.GelfLayout/GelfConverter.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfConverter.cs
@@ -27,14 +27,14 @@ namespace NLog.Layouts.GelfLayout
         public void ConvertToGelfMessage(JsonWriter jsonWriter, LogEventInfo logEventInfo, IGelfConverterOptions converterOptions)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = converterOptions.FullMessageLayout?.Render(logEventInfo) ?? string.Empty;
-            if (logEventMessage.Length > FullMessageMaxLength)
+            var fullMessage = converterOptions.FullMessage?.Render(logEventInfo) ?? string.Empty;
+            if (fullMessage.Length > FullMessageMaxLength)
             {
-                logEventMessage = logEventMessage.Substring(0, FullMessageMaxLength);
+                fullMessage = fullMessage.Substring(0, FullMessageMaxLength);
             }
 
             //Figure out the short message
-            var shortMessage = converterOptions.ShortMessageLayout?.Render(logEventInfo) ?? string.Empty;
+            var shortMessage = converterOptions.ShortMessage?.Render(logEventInfo) ?? string.Empty;
             if (shortMessage.Length > ShortMessageMaxLength)
             {
                 shortMessage = shortMessage.Substring(0, ShortMessageMaxLength);
@@ -57,11 +57,11 @@ namespace NLog.Layouts.GelfLayout
                 {
                     facility = "GELF";   //Spec says: facility must be set by the client to "GELF" if empty
                 }
-                WriteGelfVersionLegacy(jsonWriter, logEventInfo, logEventMessage, shortMessage, hostname, facility);
+                WriteGelfVersionLegacy(jsonWriter, logEventInfo, fullMessage, shortMessage, hostname, facility);
             }
             else
             {
-                WriteGelfVersion11(jsonWriter, logEventInfo, logEventMessage, shortMessage, hostname);
+                WriteGelfVersion11(jsonWriter, logEventInfo, fullMessage, shortMessage, hostname);
             }
 
             //We will persist them "Additional Fields" according to Gelf spec
@@ -130,7 +130,7 @@ namespace NLog.Layouts.GelfLayout
         /// <summary>
         /// See http://docs.graylog.org/en/2.0/pages/gelf.html#gelf-payload-specification "Specification (version 1.0)"
         /// </summary>
-        private static void WriteGelfVersionLegacy(JsonWriter jsonWriter, LogEventInfo logEventInfo, string logEventMessage, string shortMessage, string hostname, string facility)
+        private static void WriteGelfVersionLegacy(JsonWriter jsonWriter, LogEventInfo logEventInfo, string fullMessage, string shortMessage, string hostname, string facility)
         {
             jsonWriter.WritePropertyName("facility");
             jsonWriter.WriteValue((string.IsNullOrEmpty(facility) ? "GELF" : facility));
@@ -140,7 +140,7 @@ namespace NLog.Layouts.GelfLayout
             jsonWriter.WritePropertyName("file");
             jsonWriter.WriteValue(callSiteFileName);
             jsonWriter.WritePropertyName("full_message");
-            jsonWriter.WriteValue(logEventMessage);
+            jsonWriter.WriteValue(fullMessage);
             jsonWriter.WritePropertyName("host");
             jsonWriter.WriteValue(hostname);
             jsonWriter.WritePropertyName("level");
@@ -166,7 +166,7 @@ namespace NLog.Layouts.GelfLayout
         ///     file - optional, deprecated. Send as additional field instead.
         ///     line - optional, deprecated. Send as additional field instead.
         /// </remarks>
-        private static void WriteGelfVersion11(JsonWriter jsonWriter, LogEventInfo logEventInfo, string logEventMessage, string shortMessage, string hostname)
+        private static void WriteGelfVersion11(JsonWriter jsonWriter, LogEventInfo logEventInfo, string fullMessage, string shortMessage, string hostname)
         {
             jsonWriter.WritePropertyName("version");
             jsonWriter.WriteValue(GelfVersion11);
@@ -175,7 +175,7 @@ namespace NLog.Layouts.GelfLayout
             jsonWriter.WritePropertyName("short_message");
             jsonWriter.WriteValue(shortMessage);
             jsonWriter.WritePropertyName("full_message");
-            jsonWriter.WriteValue(logEventMessage);
+            jsonWriter.WriteValue(fullMessage);
             jsonWriter.WritePropertyName("timestamp");
             jsonWriter.WriteValue(ToUnixTimeStamp(logEventInfo.TimeStamp));
             jsonWriter.WritePropertyName("level");

--- a/src/NLog.Layouts.GelfLayout/GelfLayout.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayout.cs
@@ -53,10 +53,10 @@ namespace NLog.Layouts.GelfLayout
         public Layout HostName { get => _renderer.HostName; set => _renderer.HostName = value; }
 
         /// <inheritdoc/>
-        public Layout FullMessageLayout { get => _renderer.FullMessageLayout; set => _renderer.FullMessageLayout = value; }
+        public Layout FullMessage { get => _renderer.FullMessage; set => _renderer.FullMessage = value; }
         
         /// <inheritdoc/>
-        public Layout ShortMessageLayout { get => _renderer.ShortMessageLayout; set => _renderer.ShortMessageLayout = value; }
+        public Layout ShortMessage { get => _renderer.ShortMessage; set => _renderer.ShortMessage = value; }
         
         /// <inheritdoc/>
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)

--- a/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
+++ b/src/NLog.Layouts.GelfLayout/GelfLayoutRenderer.cs
@@ -63,10 +63,10 @@ namespace NLog.Layouts.GelfLayout
         public Layout HostName { get; set; } = "${hostname}";
         
         /// <inheritdoc/>
-        public Layout FullMessageLayout { get; set; } = "${message}";
+        public Layout FullMessage { get; set; } = "${message}";
         
         /// <inheritdoc/>
-        public Layout ShortMessageLayout { get; set; } = "${message}";
+        public Layout ShortMessage { get; set; } = "${message}";
 
         IList<GelfField> IGelfConverterOptions.ExtraFields { get => ExtraFields; }
 

--- a/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
+++ b/src/NLog.Layouts.GelfLayout/IGelfConverterOptions.cs
@@ -54,15 +54,15 @@ namespace NLog.Layouts.GelfLayout
         /// Graylog Message Host-field
         /// </summary>
         Layout HostName { get; }
-        
+
         /// <summary>
-        /// Layout of the rendered Full Message
+        /// Graylog Message Full-Message-field
         /// </summary>
-        Layout FullMessageLayout { get; }
-        
+        Layout FullMessage { get; }
+
         /// <summary>
-        /// Layout of the rendered Short Message
+        /// Graylog Message Short-Message-field
         /// </summary>
-        Layout ShortMessageLayout { get; }
+        Layout ShortMessage { get; }
     }
 }


### PR DESCRIPTION
Removed hungarian notation. It is not standard to add datatype-suffix to the NLog-property-names (Only unit-suffix ex. `Seconds`)